### PR TITLE
New: date shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ var result = normalize.symbol(Symbol());
 var result = normalize.boolean(true);
 var result = normalize.function(function() {});
 var result = normalize.undefined(undefined);
+var result = normalize.date(new Date());
+var result = normalize.date(1);
 ```
 
 ## API
@@ -99,6 +101,10 @@ Convenience method for `normalize('function', ...)`.
 #### `normalize.undefined(value[, ...appliedArguments])`
 
 Convenience method for `normalize('undefined', ...)`.
+
+#### `normalize.date(value[, ...appliedArguments])`
+
+Convenience method for `normalize(dateOrTimestamp, ...)` where `dateOrTimestamp` accepts both numbers and instances of `Date`.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -50,4 +50,12 @@ types.forEach(function(type) {
   normalize[type] = normalize.bind(null, type);
 });
 
+function dateOrTimestamp(value) {
+  return typeof value === 'number' ||
+    value instanceof Number ||
+    value instanceof Date;
+}
+
+normalize.date = normalize.bind(null, dateOrTimestamp);
+
 module.exports = normalize;

--- a/test/index.js
+++ b/test/index.js
@@ -241,3 +241,27 @@ describe('normalize.undefined', function() {
     done();
   });
 });
+
+describe('normalize.date', function() {
+
+  it('compares value to typeof number', function(done) {
+    var value = 1;
+    var result = normalize.date(value);
+    expect(result).toEqual(value);
+    done();
+  });
+
+  it('accepts object that are dates', function(done) {
+    var value = new Date();
+    var result = normalize.date(value);
+    expect(result).toEqual(value);
+    done();
+  });
+
+  it('rejects object that are not dates', function(done) {
+    var value = {};
+    var result = normalize.date(value);
+    expect(result).toEqual(null);
+    done();
+  });
+});


### PR DESCRIPTION
As mentioned in #1.

`date()` accepts numbers and instances of `Date`. This aligns with the needs of `vinyl-fs`.

I don't know if you want this to work in browsers. I assumed you wouldn't care so I used `instanceof`, but there are plenty of other techniques available if needed.
